### PR TITLE
fix(pr): resolve target commit from merge

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,13 +35,7 @@ async function lastPrCommit(): Promise<string> {
 }
 
 async function lastTargetCommit(): Promise<string> {
-  const { stdout } = await execa('git', [
-    'log',
-    '-n',
-    '1',
-    '--pretty=format:%H',
-    process.env.SYSTEM_PULLREQUEST_TARGETBRANCH!
-  ]);
+  const { stdout } = await execa('git', ['rev-parse', 'HEAD^1']);
   return stdout;
 }
 


### PR DESCRIPTION
Azure Pipelines doesn't like git operations that reference branches by default (probably because they're not available in the cloned repo). Switch to pulling the commit hash from the merge commit parent instead because that doesn't require branch references.